### PR TITLE
Fix memset parameter order

### DIFF
--- a/Core/Tools/WW3D/max2w3d/vchannel.cpp
+++ b/Core/Tools/WW3D/max2w3d/vchannel.cpp
@@ -451,7 +451,7 @@ bool VectorChannelClass::SaveAdaptiveDelta(ChunkSaveClass & csave, BitChannelCla
 	chn->VectorLen = VectorLen;
 	chn->Flags = Flags;
 	chn->Scale = 0.0f;
-	memset(&chn->Data[0], channelsize - (sizeof(W3dAdaptiveDeltaAnimChannelStruct) - sizeof(char)), 0x00);
+       memset(&chn->Data[0], 0x00, channelsize - (sizeof(W3dAdaptiveDeltaAnimChannelStruct) - sizeof(char)));
 	
 	assert(VectorLen <= 4);	// otherwise temp vector won't have room
 

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DPropBuffer.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DPropBuffer.cpp
@@ -122,8 +122,8 @@ for the props. */
 //=============================================================================
 W3DPropBuffer::W3DPropBuffer(void)
 {
-	memset(this, sizeof(W3DPropBuffer), 0);
-	m_initialized = false;
+       memset(this, 0, sizeof(W3DPropBuffer));
+       m_initialized = false;
 	clearAllProps();
 	m_light = NEW_REF( LightClass, (LightClass::DIRECTIONAL) );
 	m_propShroudMaterialPass = NEW_REF(W3DShroudMaterialPassClass,());

--- a/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
+++ b/GeneralsMD/Code/GameEngineDevice/Source/W3DDevice/GameClient/W3DTreeBuffer.cpp
@@ -1100,7 +1100,7 @@ for the trees. */
 //=============================================================================
 W3DTreeBuffer::W3DTreeBuffer(void)
 {
-	memset(this, sizeof(W3DTreeBuffer), 0);
+       memset(this, 0, sizeof(W3DTreeBuffer));
 	m_initialized = false;
 	Int i;
 	for	(i=0; i<MAX_BUFFERS; i++) {


### PR DESCRIPTION
## Summary
- correct parameter order for memset calls
- use size argument as last parameter

## Testing
- `cmake ..`
- `cmake --build . -j$(nproc)` *(fails: missing osdep.h)*

------
https://chatgpt.com/codex/tasks/task_e_685969cc61908324b899b716659d1314