### PR TITLE
Fix CRC::Memory parameter const correctness

### DIFF
--- a/Core/Libraries/Source/WWVegas/WWLib/CRC.H
+++ b/Core/Libraries/Source/WWVegas/WWLib/CRC.H
@@ -124,7 +124,7 @@ class CRC {
 public:
 
 	// get the CRC of a block of memory
-	static unsigned long	Memory( unsigned char *data, unsigned long length, unsigned long crc = 0 );
+	static unsigned long    Memory( const unsigned char *data, unsigned long length, unsigned long crc = 0 );
 
 	// get the CRC of a null-terminated string
 	static unsigned long	String( const char *string, unsigned long crc = 0 );

--- a/Core/Libraries/Source/WWVegas/WWLib/crc.cpp
+++ b/Core/Libraries/Source/WWVegas/WWLib/crc.cpp
@@ -203,7 +203,7 @@ unsigned long  CRC::_Table[ 256 ] =
 	0xB40BBE37L, 0xC30C8EA1L, 0x5A05DF1BL, 0x2D02EF8DL
 };
 
-unsigned long	CRC::Memory( unsigned char *data, unsigned long length, unsigned long crc )
+unsigned long	CRC::Memory( const unsigned char *data, unsigned long length, unsigned long crc )
 {
  	crc ^= 0xFFFFFFFF;									// invert previous CRC
 	while ( length-- ) {


### PR DESCRIPTION
## Summary
- make `CRC::Memory` take `const unsigned char*`

## Testing
- `cmake -S . -B build -G Ninja`
- `cmake --build build` *(fails: osdep.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_685e4feed0e483248198c438fd731a0a