### PR TITLE
Add VS2022 clang preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -162,6 +162,36 @@
             }
         },
         {
+            "name": "vs2022-clang",
+            "displayName": "VS2022 Clang Win32 Release",
+            "generator": "Visual Studio 17 2022",
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "toolset": "ClangCL",
+            "architecture": {
+                "value": "Win32",
+                "strategy": "external"
+            },
+            "cacheVariables": {
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT": "$<$<CONFIG:Release,Debug,RelWithDebInfo>:Embedded>",
+                "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL",
+                "RTS_FLAGS": "/W3"
+            },
+            "vendor": {
+                "jetbrains.com/clion": {
+                    "toolchain": "ClangCL"
+                }
+            }
+        },
+        {
+            "name": "vs2022-clang-debug",
+            "inherits": "vs2022-clang",
+            "displayName": "VS2022 Clang Win32 Debug",
+            "cacheVariables": {
+                "RTS_BUILD_OPTION_DEBUG": "ON"
+            }
+        },
+        {
             "name": "unix",
             "inherits": "default-vcpkg",
             "hidden": false,
@@ -247,6 +277,20 @@
             "configurePreset": "win32-vcpkg-debug",
             "displayName": "Build Windows 32bit VCPKG Debug",
             "description": "Build Windows 32bit VCPKG Debug",
+            "configuration": "Debug"
+        },
+        {
+            "name": "vs2022-clang",
+            "configurePreset": "vs2022-clang",
+            "displayName": "Build VS2022 Clang Win32 Release",
+            "description": "Build VS2022 Clang Win32 Release",
+            "configuration": "Release"
+        },
+        {
+            "name": "vs2022-clang-debug",
+            "configurePreset": "vs2022-clang-debug",
+            "displayName": "Build VS2022 Clang Win32 Debug",
+            "description": "Build VS2022 Clang Win32 Debug",
             "configuration": "Debug"
         },
         {
@@ -411,6 +455,32 @@
                 {
                     "type": "build",
                     "name": "win32-vcpkg-debug"
+                }
+            ]
+        },
+        {
+            "name": "vs2022-clang",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "vs2022-clang"
+                },
+                {
+                    "type": "build",
+                    "name": "vs2022-clang"
+                }
+            ]
+        },
+        {
+            "name": "vs2022-clang-debug",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "vs2022-clang-debug"
+                },
+                {
+                    "type": "build",
+                    "name": "vs2022-clang-debug"
                 }
             ]
         },

--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ report bugs, and contribute to the project!
 
 ## Building the Game Yourself
 
-We provide support for building the project using Visual Studio 6 (VS6) and Visual Studio 2022. For detailed build
-instructions, check the [Wiki](https://github.com/TheSuperHackers/GeneralsGameCode/wiki/build_guides), which also
+We provide support for building the project using Visual Studio 6 (VS6) and Visual Studio 2022.
+Visual Studio 2022 works with either the standard MSVC compiler or the Clang toolset (see the `vs2022-clang` preset).
+For detailed build instructions, check the [Wiki](https://github.com/TheSuperHackers/GeneralsGameCode/wiki/build_guides), which also
 includes guides for building with Docker, CLion, and links to forks supporting additional versions.
 
 ## Contributing


### PR DESCRIPTION
## Summary
- add a Visual Studio 2022 clang configuration to `CMakePresets.json`
- add a corresponding debug preset so VS2022 clang works for both Release and Debug builds
- document that Visual Studio can use either MSVC or clang toolsets